### PR TITLE
Use of Fortran 2008 "newunit" and few other fixes

### DIFF
--- a/example_f/example_f.f90
+++ b/example_f/example_f.f90
@@ -9,7 +9,7 @@ implicit none
  integer, parameter :: param_dim = 2!5 !dimensions of parameter space
 
  integer, parameter :: NP=10, numgen=15, numciv=1, nDerived=0
- character (len=300) :: path='example_f/output/example'
+ character (len=300) :: path='example_f'
  real(dp), parameter ::  Cr=0.9, tol = 1e-3, lambda=0.8        !0<=Cr<=1, 0<=lambda<=1
  real(dp), parameter, dimension(1) :: F=0.6                    !recommend 0<F<1
  real(dp), parameter, dimension(param_dim) :: lowerbounds=-50. ! (/-5.,-50.,1.,-50.,-1./) !boundaries of parameter space

--- a/src/evidence.f90
+++ b/src/evidence.f90
@@ -9,7 +9,7 @@ implicit none
 private
 public updateEvidence, polishEvidence
 
-integer, parameter :: rawlun=1, samlun = 2, devolun=3
+integer :: rawlun, samlun, devolun
 
 contains
 
@@ -81,11 +81,11 @@ contains
     endif
 
     !open the chain files
-    open(unit=rawlun, file=trim(path)//'.raw', &
+    open(newunit=rawlun, file=trim(path)//'.raw', &
      iostat=filestatus, status='OLD', access='DIRECT', recl=reclen_raw, form='FORMATTED')
     if (filestatus .ne. 0) call quit_all_processes(' Error opening .raw file. Quitting...')
     if (dosam) then
-      open(unit=samlun, file=trim(path)//'.sam', &
+      open(newunit=samlun, file=trim(path)//'.sam', &
        iostat=filestatus, status='OLD', access='DIRECT', recl=reclen_sam, form='FORMATTED')
       if (filestatus .ne. 0) call quit_all_processes(' Error opening .sam file. Quitting...')
     endif

--- a/src/io.f90
+++ b/src/io.f90
@@ -27,7 +27,12 @@ subroutine io_begin(path, civ, gen, Z, Zmsq, Zerr, Zold, Nsamples, Nsamples_save
   type(population), intent(inout) :: X, BF
   procedure(PriorFunc), optional :: prior
 
-  if (present(restart) .and. restart) then
+  logical           :: restart_
+
+  restart_ = .false.
+  if (present(restart)) restart_ = restart
+
+  if (restart_) then
     if (present(prior)) then
       call resume(path, civ, gen, Z, Zmsq, Zerr, Zold, Nsamples, Nsamples_saved, fcall, run_params, X, BF, prior=prior)
     else
@@ -61,7 +66,12 @@ subroutine save_all(X, BF, path, civ, gen, Z, Zmsq, Zerr, Zold, Nsamples, Nsampl
   type(codeparams), intent(in) :: run_params
   logical, intent(in), optional :: final
 
-  if (.not. present(final) .or. (present(final) .and. .not. final)) then
+  logical         :: final_
+
+  final_ = .false.
+  if (present(final)) final_ = final
+
+  if (.not. final_) then
     Nsamples_saved = Nsamples_saved + run_params%DE%NP
     call save_samples(X, path, civ, gen, run_params)
   endif

--- a/src/io.f90
+++ b/src/io.f90
@@ -10,7 +10,7 @@ implicit none
 private
 public io_begin, save_all, save_run_params, resume
 
-integer, parameter :: rawlun=1, samlun = 2, devolun=3, rparamlun=4
+integer :: rawlun, samlun, devolun, rparamlun
 real(dp), parameter :: Ztolscale = 100., Ftolscale = 100., Bndtolscale = 100.
 
 contains
@@ -38,9 +38,9 @@ subroutine io_begin(path, civ, gen, Z, Zmsq, Zerr, Zold, Nsamples, Nsamples_save
       !Create .raw and .sam files.  .rparam and .devo files are created only at first save, so their existence indicates whether
       !resuming is allowed or not.
       if (run_params%verbose .ge. 1) write(*,*) 'Creating Diver output files at '//trim(path)//'.*'
-      open(unit=rawlun, file=trim(path)//'.raw', iostat=filestatus, action='WRITE', status='REPLACE')
+      open(newunit=rawlun, file=trim(path)//'.raw', iostat=filestatus, action='WRITE', status='REPLACE')
       if ( (run_params%D_derived .ne. 0) .or. (size(run_params%discrete) .ne. 0) ) then
-         open(unit=samlun, file=trim(path)//'.sam', iostat=filestatus, action='WRITE', status='REPLACE')
+         open(newunit=samlun, file=trim(path)//'.sam', iostat=filestatus, action='WRITE', status='REPLACE')
       end if
       if (filestatus .ne. 0) call quit_all_processes(' Error creating output files. Quitting...')
       close(rawlun)
@@ -82,7 +82,7 @@ subroutine save_samples(X, path, civ, gen, run_params)
 
   if (.not. run_params%outputSamples) return
 
-  open(unit=rawlun, file=trim(path)//'.raw', iostat=filestatus, action='WRITE', status='OLD', POSITION='APPEND')
+  open(newunit=rawlun, file=trim(path)//'.raw', iostat=filestatus, action='WRITE', status='OLD', POSITION='APPEND')
   if (filestatus .ne. 0) call quit_all_processes(' Error opening raw file.  Quitting...')
   write(formatstring_raw,'(A18,I4,A6)') '(2E20.9,2x,2I6,2x,', run_params%D, 'E20.9)'
   do i = 1, size(X%weights)
@@ -91,7 +91,7 @@ subroutine save_samples(X, path, civ, gen, run_params)
   close(rawlun)
 
   if ( (run_params%D_derived .ne. 0) .or. (size(run_params%discrete) .ne. 0) ) then
-    open(unit=samlun, file=trim(path)//'.sam', iostat=filestatus, action='WRITE', status='OLD', POSITION='APPEND')
+    open(newunit=samlun, file=trim(path)//'.sam', iostat=filestatus, action='WRITE', status='OLD', POSITION='APPEND')
     if (filestatus .ne. 0) call quit_all_processes(' Error opening sam file.  Quitting...')
     write(formatstring_sam,'(A18,I4,A6)') '(2E20.9,2x,2I6,2x,', run_params%D+run_params%D_derived, 'E20.9)'
     do i = 1, size(X%weights)
@@ -113,9 +113,9 @@ subroutine save_run_params(path, run_params)
 
   inquire(file=trim(path)//'.rparam',exist=exists)
   if (exists) then
-     open(unit=rparamlun, file=trim(path)//'.rparam', iostat=filestatus, action='WRITE', status='OLD')
+     open(newunit=rparamlun, file=trim(path)//'.rparam', iostat=filestatus, action='WRITE', status='OLD')
   else
-     open(unit=rparamlun, file=trim(path)//'.rparam', iostat=filestatus, action='WRITE', status='REPLACE')
+     open(newunit=rparamlun, file=trim(path)//'.rparam', iostat=filestatus, action='WRITE', status='REPLACE')
   endif
   if (filestatus .ne. 0) call quit_all_processes(' Error opening rparam file.  Quitting...')
 
@@ -179,9 +179,9 @@ subroutine save_state(path, civ, gen, Z, Zmsq, Zerr, Zold, Nsamples, Nsamples_sa
   !Save restart info
   inquire(file=trim(path)//'.devo',exist=exists)
   if (exists) then
-     open(unit=devolun, file=trim(path)//'.devo', iostat=filestatus, action='WRITE', status='OLD')
+     open(newunit=devolun, file=trim(path)//'.devo', iostat=filestatus, action='WRITE', status='OLD')
   else
-     open(unit=devolun, file=trim(path)//'.devo', iostat=filestatus, action='WRITE', status='REPLACE')
+     open(newunit=devolun, file=trim(path)//'.devo', iostat=filestatus, action='WRITE', status='REPLACE')
   endif
   if (filestatus .ne. 0) call quit_all_processes(' Error opening devo file.  Quitting...')
 
@@ -237,7 +237,7 @@ subroutine read_state(path, civ, gen, Z, Zmsq, Zerr, Zold, Nsamples, Nsamples_sa
   !Read in run parameters
   inquire(file=trim(path)//'.rparam',exist=exists)
   if (.not. exists) call quit_all_processes(trim(path)//'.rparam does not exist. Cannot resume Diver.')
-  open(unit=rparamlun, file=trim(path)//'.rparam', iostat=filestatus, action='READ', status='OLD')
+  open(newunit=rparamlun, file=trim(path)//'.rparam', iostat=filestatus, action='READ', status='OLD')
   if (filestatus .ne. 0) call quit_all_processes(' Error opening rparam file.  Quitting...')
 
   read(rparamlun,'(I6)')     inNP                                       !population size
@@ -298,7 +298,7 @@ subroutine read_state(path, civ, gen, Z, Zmsq, Zerr, Zold, Nsamples, Nsamples_sa
   !Read in run status info
   inquire(file=trim(path)//'.devo',exist=exists)
   if (.not. exists) call quit_all_processes(trim(path)//'.devo does not exist. Cannot resume Diver.')
-  open(unit=devolun, file=trim(path)//'.devo', iostat=filestatus, action='READ', status='OLD')
+  open(newunit=devolun, file=trim(path)//'.devo', iostat=filestatus, action='READ', status='OLD')
   if (filestatus .ne. 0) call quit_all_processes(' Error opening devo file.  Quitting...')
 
   read(devolun,'(2I10)')     civ, gen                                   !current civilisation, generation
@@ -439,7 +439,7 @@ subroutine resume(path, civ, gen, Z, Zmsq, Zerr, Zold, Nsamples, Nsamples_saved,
   reclen = 57 + 20*run_params%D
 
   !open the chain file
-  open(unit=rawlun, file=trim(path)//'.raw', &
+  open(newunit=rawlun, file=trim(path)//'.raw', &
    iostat=filestatus, status='OLD', access='DIRECT', action='READ', recl=reclen, form='FORMATTED')
   if (filestatus .ne. 0) call quit_all_processes(' Error opening .raw file. Quitting...')
 


### PR DESCRIPTION
First of all, very interesting library ! :)

In this pull request I modified the ``open`` statements to use the ``newunit`` clause, since hard-coding the unit numbers can create conflicts when integrating ``diver`` with other codes. 

I also fixed the usage of some optional keywords, and changed the path of the output file for the Fortran test.