### PR TITLE
Add ability to provide guesses to be included in initial population

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,8 @@
+1.3.0 -- Feb 2025
+- Added ability to specify initial population
+- Removed Bayesian routines and civilisation loop
+- Tidied up C++ Gaussian shell example
+
 1.2.0 -- Jan 2025
 - Added python bindings
 

--- a/example_c/example_c.c
+++ b/example_c/example_c.c
@@ -34,6 +34,8 @@ const bool        disableIO            = true;                         // Disabl
 const bool        outputRaw            = false;                        // Output raw parameter samples to a .raw file
 const bool        outputSam            = false;                        // Output rounded and derived parameter samples to a .sam file
 const int         init_pop_strategy    = 0;                            // Initialisation strategy: 0=one shot, 1=n-shot, 2=n-shot with error if no valid vectors found.
+const int         nGuesses             = 0;                            // Number of individuals contained in the array of initial guesses.
+const double      initial_guesses[]    = {0};                          // Initial guesses to include in the starting population. 2D array. In C the first index is parameter, second is individual.
 const bool        discard_unfit_points = false;                        // Recalculate any trial vector whose fitness is above max_acceptable_value.  Likely incompatible with any objective function that makes MPI calls of its own.
 const int         max_init_attempts    = 10000;                        // Maximum number of times to try to find a valid vector for each slot in the initial population.
 const double      max_acceptable_val   = 1e6;                          // Maximum fitness to accept for the initial generation if init_population_strategy > 0, or any generation if discard_unfit_points = true.
@@ -64,8 +66,8 @@ int main(int argc, char** argv)
   void* context = &gauss; //Not actually used in this example.
   double result = cdiver(gauss, nPar, lowerbounds, upperbounds, path, nDerived, bestFitParams, bestFitDerived, nDiscrete,
          discrete, partitionDiscrete, maxgen, NP, nF, F, Cr, lambda, current, expon, bndry, jDE, lambdajDE, convthresh,
-         convsteps, removeDuplicates, savecount, resume, disableIO, outputRaw,
-         outputSam, init_pop_strategy, discard_unfit_points, max_init_attempts, max_acceptable_val, seed, context, verbose);
+         convsteps, removeDuplicates, savecount, resume, disableIO, outputRaw, outputSam, init_pop_strategy, nGuesses,
+         initial_guesses, discard_unfit_points, max_init_attempts, max_acceptable_val, seed, context, verbose);
   printf("Best fit returned: %e\n", result);
   for (int i = 0; i < nPar; i++) printf("Parameter %i at best fit: %e\n", i, bestFitParams[i]);
   for (int i = 0; i < nDerived; i++) printf("Derived quantity %i at best fit: %e\n", i, bestFitDerived[i]);

--- a/example_cpp/example_cpp.cpp
+++ b/example_cpp/example_cpp.cpp
@@ -35,6 +35,8 @@ const bool        disableIO            = false;                        // Disabl
 const bool        outputRaw            = true;                         // Output raw parameter samples to a .raw file
 const bool        outputSam            = false;                        // Output rounded and derived parameter samples to a .sam file
 const int         init_pop_strategy    = 2;                            // Initialisation strategy: 0=one shot, 1=n-shot, 2=n-shot with error if no valid vectors found.
+const int         nGuesses             = 0;                            // Number of individuals contained in the array of initial guesses.
+const double      initial_guesses[]    = {0};                          // Initial guesses to include in the starting population. 2D array. In C the first index is parameter, second is individual.
 const bool        discard_unfit_points = false;                        // Recalculate any trial vector whose fitness is above max_acceptable_value. Likely incompatible with any objective function that makes MPI calls of its own.
 const int         max_init_attempts    = 10000;                        // Maximum number of times to try to find a valid vector for each slot in the initial population.
 const double      max_acceptable_val   = 1e6;                          // Maximum fitness to accept for the initial generation if init_population_strategy > 0, or any generation if discard_unfit_points = true.
@@ -119,8 +121,8 @@ int main(int argc, char** argv)
 
   double result = cdiver(objective, nPar, lowerbounds, upperbounds, path, nDerived, bestFitParams, bestFitDerived, nDiscrete,
    discrete, partitionDiscrete, maxgen, NP, nF, F, Cr, lambda, current, expon, bndry, jDE, lambdajDE, convthresh, convsteps,
-   removeDuplicates, savecount, resume, disableIO, outputRaw, outputSam, init_pop_strategy, discard_unfit_points, max_init_attempts,
-   max_acceptable_val, seed, context, verbose);
+   removeDuplicates, savecount, resume, disableIO, outputRaw, outputSam, init_pop_strategy, nGuesses, initial_guesses,
+   discard_unfit_points, max_init_attempts, max_acceptable_val, seed, context, verbose);
 
   std::cout << "Best fit returned: " << result << std::endl;
   for (int i = 0; i < nPar; i++) std::cout << "Parameter " <<  i << " at best fit: " << bestFitParams[i] << std::endl;

--- a/example_f/example_f.f90
+++ b/example_f/example_f.f90
@@ -6,9 +6,7 @@ use iso_c_binding, only: c_ptr
 
 implicit none
 
- integer, parameter :: param_dim = 2!5 !dimensions of parameter space
-
- integer, parameter :: NP=10, numgen=15, nDerived=0
+ integer, parameter :: param_dim = 2 !5 !dimensions of parameter space
  character (len=300) :: path='example_f/output/example'
  real(dp), parameter ::  Cr=0.9, tol = 1e-3, lambda=0.8        !0<=Cr<=1, 0<=lambda<=1
  real(dp), parameter, dimension(1) :: F=0.6                    !recommend 0<F<1
@@ -274,10 +272,18 @@ program example_f
 
   real(dp) :: res
 
+  !Manygauss test of discrete parameters
   !res = diver(manygauss, lowerbounds, upperbounds, path, discrete=(/1,3,5/), lambdajDE=.true., &
-  !partitionDiscrete=.true., resume=.false., removeDuplicates=.true., NP=1000, bndry=3, verbose=1)
+  !partitionDiscrete=.true., resume=.false., removeDuplicates=.true., NP=1000, bndry=3, verbose=2)
 
-  res = diver(rosenbrock, lowerbounds, upperbounds, path=path, verbose=3, lambdajDE=.true., discard_unfit_points=.true.)
+  !Rosenbrock test
+  !res = diver(rosenbrock, lowerbounds, upperbounds, path=path, verbose=2, lambdajDE=.true., discard_unfit_points=.true.)
+
+  !Rosenbrock test with a first guess placed in initial population
+  real(dp), dimension(1,param_dim) :: starting_guess
+  starting_guess = 1.5
+  res = diver(rosenbrock, lowerbounds, upperbounds, path=path, verbose=3, lambdajDE=.true., discard_unfit_points=.true., &
+              initial_guesses = starting_guess)
 
   write(*,*)
   write(*,*) "Minimum found:", res

--- a/example_py/example.py
+++ b/example_py/example.py
@@ -15,6 +15,7 @@ def gauss(p: NDArray[np.float64], fcall: int, finish: bool, validvector: bool, c
 def main():
   N=10
   opts = diver.defaults(upperbounds=[2]*N, lowerbounds=[-2]*N)
+  opts["NP"] = 100
   s = diver.run(gauss, opts)
   print(f"Min in {N:>2d}D: ", s[0])
   print("Found at: ", s[1])

--- a/include/diver.h
+++ b/include/diver.h
@@ -2,4 +2,5 @@
 // C prototype of the main run_de function for Diver.
 extern double cdiver(double (*)(double[], const int, int*, bool*, const bool, void**), int, const double[], const double[],
        const char[], int, double[], double[], int, const int[], bool, int, int, int, const double[], double, double, bool,
-       bool, int, bool, bool, double, int, bool, int, bool, bool, bool, bool, int, bool, int, double, int, void**, int);
+       bool, int, bool, bool, double, int, bool, int, bool, bool, bool, bool, int, int, const double[], bool, int, double, int,
+       void**, int);

--- a/include/diver.hpp
+++ b/include/diver.hpp
@@ -2,4 +2,5 @@
 #pragma once
 extern "C" double cdiver(double (*)(double[], const int, int&, bool&, const bool, void*&), int, const double[], const double[],
            const char[], int, double[], double[], int, const int[], bool, int, int, int, const double[], double, double, bool,
-           bool, int, bool, bool, double, int, bool, int, bool, bool, bool, bool, int, bool, int, double, int, void*&, int);
+           bool, int, bool, bool, double, int, bool, int, bool, bool, bool, bool, int, int, const double[], bool, int, double, int,
+           void*&, int);

--- a/include/python_binding.hpp
+++ b/include/python_binding.hpp
@@ -18,7 +18,7 @@ namespace diver
   /// You could call this from C++ too though, if you prefer its signature to the C-style signature of cdiver (in diver.hpp).
   std::tuple<double, py::array_t<double>, py::array_t<double>> diver_cpp(func_type, py::array_t<double>&, py::array_t<double>&,
    const char[], int, py::array_t<int>&, bool, int, int, py::array_t<double>&, double, double, bool, bool, int, bool, bool,
-   double, int, bool, int, bool, bool, bool, bool, int, bool, int, double, int, py::object&, int);
+   double, int, bool, int, bool, bool, bool, bool, int, py::array_t<double>&, bool, int, double, int, py::object&, int);
 
 }
 
@@ -51,6 +51,7 @@ PYBIND11_MODULE(diver_cpp, m) {
         py::arg("outputRaw"),
         py::arg("outputSam"),
         py::arg("init_population_strategy"),
+        py::arg("initial_guesses"),
         py::arg("discard_unfit_points"),
         py::arg("max_initialisation_attempts"),
         py::arg("max_acceptable_value"),

--- a/python/diver/__init__.py
+++ b/python/diver/__init__.py
@@ -39,6 +39,7 @@ class options(TypedDict):
     outputRaw [bool]: output raw parameter samples to a .raw file.
     outputSam [bool]: output rounded and derived parameter samples to a .sam file.
     init_population_strategy [int]: initialisation strategy: 0=one shot, 1=n-shot, 2=n-shot with error if no valid vectors found.
+    initial_guesses [NDArray[np.float64]]: Initial guesses to include in the starting population. 2D array. In Python the first index is parameter, second is individual.
     discard_unfit_points [bool]: recalculate any trial vector whose fitness is above max_acceptable_value. Likely incompatible with any objective function that makes MPI calls of its own.
     max_initialisation_attempts [int]: maximum number of times to try to find a valid vector for each slot in the initial population.
     max_acceptable_value [float]: maximum fitness to accept for the initial generation if init_population_strategy > 0. Also applies to later generations if discard_unfit_points = .true.
@@ -71,6 +72,7 @@ class options(TypedDict):
   outputRaw: bool
   outputSam: bool
   init_population_strategy: int
+  initial_guesses: NDArray[np.float64]
   discard_unfit_points: bool
   max_initialisation_attempts: int
   max_acceptable_value: float
@@ -106,6 +108,7 @@ def defaults(lowerbounds, upperbounds):
        'outputRaw': True,
        'outputSam': True,
        'init_population_strategy': 0,
+       'initial_guesses': np.array([], dtype=np.float64),
        'discard_unfit_points': False,
        'max_initialisation_attempts': 10000,
        'max_acceptable_value': 1e6,

--- a/src/cwrapper.f90
+++ b/src/cwrapper.f90
@@ -33,6 +33,8 @@
 !               bool outputRaw,
 !               bool outputSam,
 !               int init_population_strategy,
+!               int nGuesses,
+!               const double initial_guesses[],
 !               bool discard_unfit_points,
 !               int max_initialisation_attempts,
 !               double max_acceptable_value,
@@ -93,6 +95,8 @@ contains
                     outputRaw, &
                     outputSam, &
                     init_population_strategy, &
+                    nGuesses, &
+                    initial_guesses, &
                     discard_unfit_points, &
                     max_initialisation_attempts, &
                     max_acceptable_value, &
@@ -109,13 +113,14 @@ contains
     real(c_double)                       :: cdiver
     type(c_funptr),  intent(in), value   :: minusloglike_in
     type(c_ptr),     intent(inout)       :: context
-    integer(c_int),  intent(in), value   :: nPar, nDerived, nDiscrete, maxgen, NP, nF, bndry, convsteps, savecount, verbose
-    integer(c_int),  intent(in), value   :: init_population_strategy, max_initialisation_attempts, seed
+    integer(c_int),  intent(in), value   :: nPar, nDerived, nDiscrete, nGuesses, maxgen, NP, nF, bndry, convsteps
+    integer(c_int),  intent(in), value   :: savecount, verbose, init_population_strategy, max_initialisation_attempts, seed
     integer(c_int),  intent(in), target  :: discrete(nDiscrete)
     logical(c_bool), intent(in), value   :: partitionDiscrete, current, expon, jDE, lambdajDE, removeDuplicates, resume
     logical(c_bool), intent(in), value   :: disableIO, outputRaw, outputSam, discard_unfit_points
     real(c_double),  intent(in), value   :: Cr, lambda, convthresh, max_acceptable_value
     real(c_double),  intent(in)          :: lowerbounds(nPar), upperbounds(nPar), F(nF)
+    real(c_double),  intent(in), target  :: initial_guesses(nGuesses, nPar)
     real(c_double),  intent(out)         :: bestFitParams(nPar)
     real(c_double),  intent(out), target :: bestFitDerived(nDerived)
     character(kind=c_char,len=1), dimension(maxpathlen), intent(in) :: path
@@ -125,6 +130,8 @@ contains
     integer, pointer :: discrete_f(:)
     real(c_double), target :: bestFitDerived_empty(0)
     real(c_double), pointer :: bestFitDerived_f(:)
+    real(c_double), target :: initial_guesses_empty(0,0)
+    real(c_double), pointer :: initial_guesses_f(:,:)
     character(len=maxpathlen) :: path_f
 
     ! Set the pointer to the likelihood function
@@ -152,6 +159,13 @@ contains
       discrete_f => discrete_empty
     else
       discrete_f => discrete
+    endif
+
+    ! Fix up the potential null pointer passed in instead of an illegal zero-element C array if nGuesses = 0
+    if (nGuesses .eq. 0) then
+      initial_guesses_f => initial_guesses_empty
+    else
+      initial_guesses_f => initial_guesses
     endif
 
     ! Call the actual fortran differential evolution function
@@ -182,6 +196,7 @@ contains
                    outputRaw=logical(outputRaw), &
                    outputSam=logical(outputSam), &
                    init_population_strategy=init_population_strategy, &
+                   initial_guesses=initial_guesses, &
                    discard_unfit_points=logical(discard_unfit_points), &
                    max_initialisation_attempts=max_initialisation_attempts, &
                    max_acceptable_value=max_acceptable_value, &

--- a/src/de.f90
+++ b/src/de.f90
@@ -49,6 +49,7 @@ contains
                  outputRaw, &
                  outputSam, &
                  init_population_strategy, &
+                 initial_guesses, &
                  discard_unfit_points, &
                  max_initialisation_attempts, &
                  max_acceptable_value, &
@@ -83,6 +84,7 @@ contains
     integer, intent(in), optional    :: savecount               !save progress every savecount generations
     logical, intent(in), optional    :: resume                  !restart from a previous run
     integer, intent(in), optional    :: init_population_strategy!initialisation strategy: 0=one shot, 1=n-shot, 2=n-shot with error if no valid vectors found.
+    real(dp), dimension(:,:), intent(in), optional :: initial_guesses !initial guesses to include in the starting population. In Fortran the first index is individual, second is parameter.
     logical, intent(in), optional    :: discard_unfit_points    !recalculate any trial vector whose fitness is above max_acceptable_value. Likely incompatible with any objective function that makes MPI calls of its own.
     integer, intent(in), optional    :: max_initialisation_attempts !maximum number of times to try to find a valid vector for each slot in the initial population.
     real(dp), intent(in), optional   :: max_acceptable_value    !maximum fitness to accept for the initial generation if init_population_strategy > 0. Also applies to later generations if discard_unfit_points = .true.
@@ -155,6 +157,7 @@ contains
                       outputRaw=outputRaw, &
                       outputSam=outputSam, &
                       init_population_strategy=init_population_strategy, &
+                      initial_guesses=initial_guesses, &
                       discard_unfit_points=discard_unfit_points, &
                       max_initialisation_attempts=max_initialisation_attempts, &
                       max_acceptable_value=max_acceptable_value, &
@@ -212,7 +215,6 @@ contains
        endif
     endif
 
-
     !DE loop: calculates population for each generation
     genloop: do gen = genstart, run_params%numgen
 
@@ -227,7 +229,7 @@ contains
          call init_convergence(run_params)
 
          !initialise the first generation
-         call initialize(X, Xnew, run_params, func, fcall, quit, accept)
+         call initialize(X, Xnew, run_params, initial_guesses, func, fcall, quit, accept)
 
          !sync quit flags
          quit = sync(quit)

--- a/src/init.f90
+++ b/src/init.f90
@@ -15,7 +15,7 @@ implicit none
 private
 public param_assign, initialize, init_all_random_seeds
 
-character (len=*), parameter :: version_number = "1.2.0"
+character (len=*), parameter :: version_number = "1.3.0"
 
 contains
 
@@ -47,6 +47,7 @@ contains
                           outputRaw, &
                           outputSam, &
                           init_population_strategy, &
+                          initial_guesses, &
                           discard_unfit_points, &
                           max_initialisation_attempts, &
                           max_acceptable_value, &
@@ -81,6 +82,7 @@ contains
     logical, intent(in), optional  :: outputRaw                         !output raw parameter samples to a .raw file
     logical, intent(in), optional  :: outputSam                         !output rounded and derived parameter samples to a .sam file
     integer, intent(in), optional  :: init_population_strategy          !initialisation strategy: 0=one shot, 1=n-shot, 2=n-shot with error if no valid vectors found.
+    real(dp), dimension(:,:), intent(in), optional :: initial_guesses   !initial guesses to include in the starting population. In Fortran the first index is individual, second is parameter.
     logical, intent(in), optional  :: discard_unfit_points              !recalculate any trial vector whose fitness is above max_acceptable_value. Likely incompatible with any objective function that makes MPI calls of its own.
     integer, intent(in), optional  :: max_initialisation_attempts       !maximum number of times to try to find a valid vector for each slot in the initial population.
     real(dp), intent(in), optional :: max_acceptable_value              !maximum fitness to accept for the initial generation if init_population_strategy > 0. Also applies to later generations if discard_unfit_points = .true.
@@ -139,7 +141,7 @@ contains
     run_params%D=size(lowerbounds)
 
     if (size(upperbounds) .ne. run_params%D) call quit_de('ERROR: parameter space bounds do not have the same dimensionality')
-    if (any(lowerbounds .ge. upperbounds)) call quit_de('ERROR: invalid parameter space bounds.')
+    if (any(lowerbounds .ge. upperbounds)) call quit_de('ERROR: upperbounds must be greater than lowerbounds')
 
     allocate(run_params%lowerbounds(run_params%D), run_params%upperbounds(run_params%D))
     run_params%lowerbounds = lowerbounds
@@ -481,13 +483,21 @@ contains
           write (*,*) 'Reflective boundary constraints'
        end select
 
+      !User-provided initial population
+      if (present(initial_guesses) .and. size(initial_guesses) .gt. 0) then
+        if (size(initial_guesses,2) .ne. run_params%D) call quit_de ('ERROR: each initial guess must consist of D = ' // &
+         trim(int_to_string(run_params%D)) // ' parameter values.')
+        write(*,*) 'Using user-supplied guesses to seed ' // &
+         trim(int_to_string(size(initial_guesses,1))) // ' points in the initial population.'
+      endif
+
        select case (run_params%init_population_strategy)     !initialisation strategy
        case (0)
           write (*,*) 'Validity of initial generation will not be enforced.'
        case (1)
           write (*,*) 'Will make', run_params%max_initialisation_attempts, 'attempts to find a point with value below', &
            run_params%max_acceptable_value
-          write (*,*) 'when generating the initialial population.  After this, invalid points will be permitted.'
+          write (*,*) 'when generating initial population members.  After this, invalid points will be permitted.'
        case (2)
           write (*,*) 'Will get', run_params%max_initialisation_attempts, 'attempts to find a point with value below', &
            run_params%max_acceptable_value
@@ -501,7 +511,6 @@ contains
           write (*,*) 'New trial vectors will be generated until all have values below', &
            run_params%max_acceptable_value
        end select
-
 
     end if
 
@@ -584,17 +593,19 @@ contains
 
 
   !initializes first generation of target vectors
-  subroutine initialize(X, Xnew, run_params, func, fcall, quit, accept)
+  subroutine initialize(X, Xnew, run_params, initial_guesses, func, fcall, quit, accept)
 
     type(population), intent(inout) :: X
     type(population), intent(inout) :: Xnew
     type(codeparams), intent(inout) :: run_params
+    real(dp), dimension(:,:), intent(in), optional :: initial_guesses
     integer, intent(inout) :: fcall
     logical, intent(inout) :: quit
     procedure(MinusLogLikeFunc) :: func
     integer :: n, m, i, discrete_index, attempt_count, max_attempts, accept
 
-    if (run_params%DE%jDE) then                              !initialize population of F and Cr parameters
+    !initialize population of F and Cr parameters
+    if (run_params%DE%jDE) then
        Xnew%FjDE = init_FjDE(run_params%mpipopchunk)
        Xnew%CrjDE = init_CrjDE(run_params%mpipopchunk)
        if (run_params%DE%lambdajDE) then
@@ -605,39 +616,49 @@ contains
     !loop over the vectors belonging to each population chunk
     do m=1,run_params%mpipopchunk
 
-       n = run_params%mpipopchunk*run_params%mpirank + m !true population index (equal to m if no mpi)
+       !true population index (equal to m if no mpi)
+       n = run_params%mpipopchunk*run_params%mpirank + m
 
-       !if init_population_strategy is not 0, try to find a valid individual to put in the initial population.
+       !Find valid individuals to put in the initial population.
        attempt_count = 0
        max_attempts = merge(1, run_params%max_initialisation_attempts, run_params%init_population_strategy .eq. 0)
        do while (attempt_count .lt. max_attempts)
 
-          call random_number(Xnew%vectors(m,:))
+          !if there are initial guesses still to be used, simply copy from the initial population. Otherwise, generate a new individual.
+          if (present(initial_guesses) .and. n .le. size(initial_guesses,1)) then
 
-          do i = 1, run_params%D
+            Xnew%vectors(m,:) = initial_guesses(n, :)
 
-             if (run_params%partitionDiscrete .and. any(run_params%discrete .eq. i)) then
-                !This is a discrete parameter that needs to be partitioned, and therefore set rather than chosen randomly
+          else
 
-                !Determine the index of the discrete parameter (first discrete param, second, etc)
-                do discrete_index = 1, run_params%D_discrete
-                   if (run_params%discrete(discrete_index) .eq. i) exit
-                enddo
+            call random_number(Xnew%vectors(m,:))
 
-                !Set the value of this index for this individual
-                Xnew%vectors(m,i) = anint( dble(mod(n-1,run_params%repeat_scales(discrete_index))) / &
-                                           dble(run_params%repeat_scales(discrete_index)) * &
-                                           (run_params%upperbounds(i) - run_params%lowerbounds(i) + 1) &
-                                           + run_params%lowerbounds(i) - 0.5_dp + 100._dp*epsilon(0.5_dp) )
+            do i = 1, run_params%D
 
-             else
-                !This is a normal parameter that needs to be chosen randomly
-                Xnew%vectors(m,i) = Xnew%vectors(m,i)*(run_params%upperbounds(i) - &
-                                    run_params%lowerbounds(i)) + run_params%lowerbounds(i)
+               if (run_params%partitionDiscrete .and. any(run_params%discrete .eq. i)) then
+                  !This is a discrete parameter that needs to be partitioned, and therefore set rather than chosen randomly
 
-             endif
+                  !Determine the index of the discrete parameter (first discrete param, second, etc)
+                  do discrete_index = 1, run_params%D_discrete
+                     if (run_params%discrete(discrete_index) .eq. i) exit
+                  enddo
 
-          enddo
+                  !Set the value of this index for this individual
+                  Xnew%vectors(m,i) = anint( dble(mod(n-1,run_params%repeat_scales(discrete_index))) / &
+                                             dble(run_params%repeat_scales(discrete_index)) * &
+                                             (run_params%upperbounds(i) - run_params%lowerbounds(i) + 1) &
+                                             + run_params%lowerbounds(i) - 0.5_dp + 100._dp*epsilon(0.5_dp) )
+
+               else
+                  !This is a normal parameter that needs to be chosen randomly
+                  Xnew%vectors(m,i) = Xnew%vectors(m,i)*(run_params%upperbounds(i) - &
+                                      run_params%lowerbounds(i)) + run_params%lowerbounds(i)
+
+               endif
+
+            enddo
+
+          endif
 
           Xnew%vectors_and_derived(m,:run_params%D) = roundvector(Xnew%vectors(m,:), run_params)
 
@@ -652,7 +673,7 @@ contains
        enddo
 
        !crash if valid vectors have been demanded in the initial population but could not be found.
-       if (run_params%init_population_strategy .ge. 2 .and. attempt_count .eq. max_attempts) then
+       if (run_params%init_population_strategy .eq. 2 .and. attempt_count .eq. max_attempts) then
          call quit_de('ERROR: init_population_strategy = 2 but could not find valid points within max_initialisation_attempts!')
        endif
 

--- a/src/python_binding.cpp
+++ b/src/python_binding.cpp
@@ -55,6 +55,7 @@ namespace diver
     bool outputRaw,
     bool outputSam,
     int init_population_strategy,
+    py::array_t<double>& initial_guesses,
     bool discard_unfit_points,
     int max_initialisation_attempts,
     double max_acceptable_value,
@@ -74,6 +75,9 @@ namespace diver
     info = F.request();
     double* F_ptr = static_cast<double*>(info.ptr);
     int nF = info.shape[0];
+    info = initial_guesses.request();
+    double* initial_guesses_ptr = static_cast<double*>(info.ptr);
+    int nGuesses = info.shape[1];
     // Create and get data pointers to output arrays.
     py::array_t<double> bestFitParams({nPar}, {sizeof(double)});
     double* bestFitParams_ptr = static_cast<double*>(bestFitParams.request().ptr);
@@ -114,6 +118,8 @@ namespace diver
                         outputRaw,
                         outputSam,
                         init_population_strategy,
+                        nGuesses,
+                        initial_guesses_ptr,
                         discard_unfit_points,
                         max_initialisation_attempts,
                         max_acceptable_value,


### PR DESCRIPTION
This PR solves #12 by adding the `initial_guesses` parameter to the main diver function, allowing arbitrarily many parameter sets to be provided as initial guesses.  

Each of the guesses is put into the initial population, in place of a randomly generated population member.  Validity tests of the initial population proceed as before, i.e. the initial guesses are subject to any validity tests applied to randomly-generated initial population members, and thrown out if they fail those tests.  When a guess is thrown out, the next guess is tried.  When all provided guesses are exhausted, the remaining initial population members are randomly generated as before, according the chosen value of `intial_pop_strategy`.

I've tested by tinkering with the examples that this all works properly in Fortran, C++ and Python.  I've left the test code active in the Fortran example, and suggest that we ship it this way as an example of how to pass an initial guess. 

Note that this PR continues straight off the tip of #13, so needs to be rebased against the `master` once #13 is merged.